### PR TITLE
python3 and travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.egg-info
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+before_install:
+  - "pip install -U pip"
+install:
+  - "pip install -e .[test]"
+script:
+  - "py.test tests/"
+  - "pylint pydpkg/"
+  - "pep8 pydpkg/"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/TheClimateCorporation/python-dpkg.svg?branch=master)](https://travis-ci.org/TheClimateCorporation/python-dpkg)
+
 python-dpkg
 ===========
 
@@ -14,8 +16,8 @@ This is primarily intended for use on platforms that do not normally
 ship [python-apt](http://apt.alioth.debian.org/python-apt-doc/) due to
 licensing restrictions or the lack of a native libapt.so (e.g. macOS)
 
-Currently only tested on Python 2.6 and 2.7.  Should run on any python2
-distribution that can install the [arpy](https://pypi.python.org/pypi/arpy/)
+Currently only tested on CPython 2.7 and 3.5, but at least in theory should run
+on any python distribution that can install the [arpy](https://pypi.python.org/pypi/arpy/)
 library.
    
 Installing
@@ -26,9 +28,9 @@ the [pip](https://packaging.python.org/installing/) tool:
 
     $ pip install pydpkg
     Collecting pydpkg
-      Downloading pydpkg-1.0-py2-none-any.whl
+      Downloading pydpkg-1.1-py2-none-any.whl
       Installing collected packages: pydpkg
-      Successfully installed pydpkg-1.0
+      Successfully installed pydpkg-1.1
 
 Usage
 =====
@@ -52,6 +54,28 @@ Read and extract headers
     Maintainer: Climate Corp Engineering <no-reply@climate.com>
     Description: testdeb
      a bogus debian package for testing dpkg builds
+
+Interact directly with the package control message
+--------------------------------------------------
+
+    >>> dp.message
+    <email.message.Message instance at 0x10895c6c8>
+    >>> dp.message.get_content_type()
+    'text/plain'
+
+Get package file fingerprints
+-----------------------------
+
+    >>> dp.fileinfo
+    {'sha256': '547500652257bac6f6bc83f0667d0d66c8abd1382c776c4de84b89d0f550ab7f', 'sha1': 'a5d28ae2f23e726a797349d7dd5f21baf8aa02b4', 'filesize': 910, 'md5': '149e61536a9fe36374732ec95cf7945d'}
+    >>> dp.md5
+    '149e61536a9fe36374732ec95cf7945d'
+    >>> dp.sha1
+    'a5d28ae2f23e726a797349d7dd5f21baf8aa02b4'
+    >>> dp.sha256
+    '547500652257bac6f6bc83f0667d0d66c8abd1382c776c4de84b89d0f550ab7f'
+    >>> dp.filesize
+    910
 
 Get an arbitrary control header, case-independent
 -------------------------------------------------
@@ -86,3 +110,24 @@ Use as a cmp function to sort a list of version strings
     >>> from pydpkg import Dpkg
     >>> sorted(['0:1.0-test1', '1:0.0-test0', '0:1.0-test2'] , cmp=Dpkg.compare_versions)
     ['0:1.0-test1', '0:1.0-test2', '1:0.0-test0']
+
+Use the `dpkg-inspect.py` script to inspect packages
+----------------------------------------------------
+
+    $ dpkg-inspect.py ~/testdeb*deb
+    Filename: /Home/n/testdeb_1:0.0.0-test_all.deb
+    Size:     910
+    MD5:      149e61536a9fe36374732ec95cf7945d
+    SHA1:     a5d28ae2f23e726a797349d7dd5f21baf8aa02b4
+    SHA256:   547500652257bac6f6bc83f0667d0d66c8abd1382c776c4de84b89d0f550ab7f
+    Headers:
+      Package: testdeb
+      Version: 1:0.0.0-test
+      Section: base
+      Priority: extra
+      Architecture: all
+      Installed-Size: 0
+      Maintainer: Nathan Mehl <n@climate.com>
+      Description: testdeb
+       a bogus debian package for testing dpkg builds
+

--- a/scripts/dpkg-inspect.py
+++ b/scripts/dpkg-inspect.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import glob
+import logging
+import os
+import sys
+
+from pydpkg import Dpkg
+
+logging.basicConfig()
+log = logging.getLogger('dpkg_extract')
+log.setLevel(logging.INFO)
+
+PRETTY = """Filename: {0}
+Size:     {1}
+MD5:      {2}
+SHA1:     {3}
+SHA256:   {4}
+Headers:
+{5}"""
+
+
+def indent(input_str, prefix):
+    return '\n'.join(
+        ['%s%s' % (prefix, x) for x in input_str.split('\n')]
+    )
+
+try:
+    filenames = sys.argv[1:]
+except KeyError:
+    log.fatal('You must list at least one deb file as an argument')
+    sys.exit(1)
+
+for files in filenames:
+    for fn in glob.glob(files):
+        if not os.path.isfile(fn):
+            log.warning('%s is not a file, skipping', fn)
+        log.debug('checking %s', fn)
+        dp = Dpkg(fn)
+        print(PRETTY.format(
+            fn, dp.filesize, dp.md5, dp.sha1, dp.sha256,
+            indent(str(dp), '  ')
+        ))

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,32 @@
 from distutils.core import setup
 setup(
-      name = 'pydpkg',
-      packages = ['pydpkg'], # this must be the same as the name above
-      version = '1.0',
-      description = 'A python library for parsing debian package control headers and comparing version strings',
-      author = 'Nathan J. Mehl',
-      author_email = 'n@climate.com',
-      url = 'https://github.com/theclimatecorporation/python-dpkg',
-      download_url = 'https://github.com/theclimatecorporation/python-dpkg/tarball/1.0',
-      keywords = ['apt', 'debian', 'dpkg', 'packaging'],
-      classifiers=[
-          "Development Status :: 5 - Production/Stable",
-          "License :: OSI Approved :: Apache Software License",
-          "Programming Language :: Python :: 2.6",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: Implementation :: CPython",
-          "Topic :: System :: Archiving :: Packaging",
-          ]
+    name='pydpkg',
+    packages=['pydpkg'],  # this must be the same as the name above
+    version='1.1',
+    description='A python library for parsing debian package control headers and comparing version strings',
+    author='Nathan J. Mehl',
+    author_email='n@climate.com',
+    url='https://github.com/theclimatecorporation/python-dpkg',
+    download_url='https://github.com/theclimatecorporation/python-dpkg/tarball/1.1',
+    keywords=['apt', 'debian', 'dpkg', 'packaging'],
+    install_requires=[
+        'arpy==1.1.1',
+        'six==1.10.0'
+    ],
+    extras_require={
+        'test': ['pep8==1.7.0', 'pytest==3.1.1', 'pylint==1.7.1']
+    },
+    scripts=[
+        'scripts/dpkg-inspect.py'
+    ],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: System :: Archiving :: Packaging",
+        ]
 )

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
+from functools import cmp_to_key
 
 from pydpkg import Dpkg, DpkgVersionError
 
@@ -65,8 +66,9 @@ class DpkgTest(unittest.TestCase):
         # taken from
         # http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
         self.assertEqual(
-                sorted(['a', '', '~', '~~a', '~~'], cmp=Dpkg.dstringcmp),
-                ['~~', '~~a', '~', '', 'a'])
+            sorted(['a', '', '~', '~~a', '~~'],
+                   key=cmp_to_key(Dpkg.dstringcmp)),
+            ['~~', '~~a', '~', '', 'a'])
 
     def test_compare_revision_strings(self):
         # note that these are testing a single revision string, not the full


### PR DESCRIPTION
- python3 compatibility
- drop py2.6 support
- use email.message rather than rfc822.message
- add some initial debug logging
- pylint and pep8 fixes
- add object properties for file hashes
- add a simple cli demo script
- add travis for continuous build