### PR TITLE
Extend the compatibility with Python 3.6 and 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-__VERSION__ = '1.3.1'
+__VERSION__ = '1.3.2'
 
 setup(
     name='pydpkg',
@@ -14,7 +14,7 @@ setup(
     keywords=['apt', 'debian', 'dpkg', 'packaging'],
     install_requires=[
         'arpy==1.1.1',
-        'six==1.10.0',
+        'six==1.12.0',
         'PGPy==0.4.1'
     ],
     extras_require={
@@ -30,6 +30,8 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Archiving :: Packaging",
         ]


### PR DESCRIPTION
This patch extends the compatibility with Python 3.6 and 3.7.
Additionally it extends the six dependency version to 1.12.0 that
may causes some cross compatibility with other sub-dependecies.

Proposed release 1.3.2